### PR TITLE
Ruby 1.8 compatibility for setup and track actions

### DIFF
--- a/workflow/lib/alfredfm_helper.rb
+++ b/workflow/lib/alfredfm_helper.rb
@@ -35,7 +35,9 @@ class AlfredfmHelper
   # @param filename [String] name of the file to save
   # @param hash [Hash] hash to save onto file
   def self.save_hash_to_file path, filename, hash
-    File.write(File.join(@@paths[path], filename), hash.to_yaml)
+    File.open(File.join(@@paths[path], filename), 'w') do |f|
+      f.write hash.to_yaml
+    end
   end
 
   # Generate a Universally Uniqued Identifier

--- a/workflow/lib/alfredfm_helper.rb
+++ b/workflow/lib/alfredfm_helper.rb
@@ -7,14 +7,7 @@ require 'uri'
 require 'net/http'
 
 class AlfredfmHelper
-
-  # Used to Map Actions to String
-  ACTIONS = {
-    :love       => 'Loved',
-    :ban        => 'Banned',
-    :add_tags   => 'Tagged',
-    :remove_tag => 'Untagged'
-  }
+  ACTIONS = {:love => 'Loved', :add_tags => 'Tagged', :ban => 'Banned', :remove_tag => 'Untagged'}
 
   def initialize alfred
     app_info   = YAML.load_file('info.yml')


### PR DESCRIPTION
- Fixes the faulty authorization process under Ruby 1.8 by changing `File.write` semantics (the config file was never written under Ruby 1.8; pretty sure I fixed this before – I must have mangled the changes somewhere downstream).
- Fixes the refactored track actions under Ruby 1.8 by switching to “old style” Hash declaration syntax (NB: the `{symbol: value}` shorthand syntax has been introduced with Ruby 1.9 – Ruby 1.8 compatible code **needs** to use the `{:symbol => value}` syntax.
